### PR TITLE
Add setting in docker compose to set shm_size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - postgis-data:/var/lib/postgresql
       - ./postgis/postgresql.conf:/etc/postgresql/postgresql.conf
       - share:/share
+    shm_size: 2gb
     restart: unless-stopped
     healthcheck:
       test: 'exit 0'


### PR DESCRIPTION
Set shared memory size for the postgis service to 2gb in docker compose